### PR TITLE
openrc: add touch-ostree service

### DIFF
--- a/Dockerfile.openrc
+++ b/Dockerfile.openrc
@@ -10,6 +10,7 @@ COPY machine/$MACHINE/hostname /etc/machine
 # custom services
 COPY openrc/apps/apps.initd /etc/init.d/apps
 COPY openrc/tmpfiles/tmpfiles.initd /etc/init.d/tmpfiles
+COPY openrc/ostree/touch-ostree.initd /etc/init.d/touch-ostree
 # COPY openrc/mountfs/mountfs.initd /etc/init.d/mountfs
 # RUN sed -i "s/@@NULIX_VIRT_BACKEND@@/${NULIX_VIRT_BACKEND}/g" /etc/init.d/mountfs
 #COPY openrc/rauc/rauc.initd /etc/init.d/rauc
@@ -39,6 +40,7 @@ RUN rc-update add networking boot
 RUN rc-update add sysctl boot
 #RUN rc-update add rauc-hawkbit-updater default
 #RUN rc-update add rauc-mark-good default
+RUN rc-update add touch-ostree default
 RUN rc-update add killprocs shutdown
 RUN rc-update add mount-ro shutdown
 

--- a/openrc/ostree/touch-ostree.initd
+++ b/openrc/ostree/touch-ostree.initd
@@ -1,0 +1,17 @@
+#!/sbin/openrc-run
+
+# Copyright (c) NULIX 2024
+# This code is licensed under BSD-2-Clause
+
+name="ostree booted service"
+description="Service which indicates OSTree boot"
+
+depend() {
+	keyword -prefix -lxc -docker
+}
+
+start() {
+    ebegin "Starting OSTree booted service"
+    touch /run/ostree-booted
+    eend $?
+}


### PR DESCRIPTION
This service creates an empty `/run/ostree-booted` file which indicates that we are running an OSTree instance, and it helps determine which one while issuing the `ostree admin status` command (it will be flagged with `*` in the output).