### PR TITLE
ostree: fix build error when moving libs dir

### DIFF
--- a/Dockerfile.ostree
+++ b/Dockerfile.ostree
@@ -22,17 +22,20 @@ RUN mkdir -p /usr/sbin && \
     ln -s usr/sbin /sbin
 RUN mkdir -p /usr/lib && \
     cp -a /lib/* /usr/lib && \
-    patchelf --set-interpreter /usr/lib/ld-musl-*.so.* /bin/busybox && \
-    rm -rf /lib && \
-    ln -s usr/lib /lib && \
-    patchelf --set-interpreter /lib/ld-musl-*.so.* /bin/busybox && \
+    cp /usr/bin/busybox /tmp && \
+    patchelf --set-interpreter /usr/lib/ld-musl-*.so.* /tmp/busybox
+SHELL ["/tmp/busybox", "sh", "-c"]
+RUN rm -rf /lib && \
+    /tmp/busybox ln -s usr/lib /lib && \
     apk del patchelf
-RUN if [ -d "/lib64" ]; then \
+RUN if [ -d /lib64 ]; then \
       mkdir -p /usr/lib64; \
       cp -a /lib64/* /usr/lib64; \
       rm -rf /lib64; \
       ln -s usr/lib64 /lib64; \
     fi
+SHELL ["/bin/busybox", "sh", "-c"]
+RUN rm /tmp/busybox
 
 # preserve var/lib/$NULIX_VIRT_BACKEND
 RUN if [ -d var/lib/$NULIX_VIRT_BACKEND ]; then \
@@ -53,8 +56,7 @@ RUN if [ -d var/local ]; then \
 RUN rm -rf var/lib && \
     rm -rf var/cache && \
     rm -rf var && \
-    mkdir var && \
-    mkdir var/cache
+    mkdir var
 
 # get back var/local
 RUN if [ -d var-local ]; then \


### PR DESCRIPTION
This fixes the following build error:
```sh
patchelf: open: Text file busy
```