### PR TITLE
machine: rpi: fix fw_printenv environment file path

### DIFF
--- a/machine/rpi/fw_env.config.in
+++ b/machine/rpi/fw_env.config.in
@@ -1,1 +1,1 @@
-/boot/uboot.env 0x0000    0x4000
+/mnt/boot/uboot.env 0x0000    0x4000


### PR DESCRIPTION
Use the `/mnt/boot/uboot.env` file by default.