### PR TITLE
apps: change location of apps compose file to /usr/apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ Thumbs.db
 
 # Directories #
 ###############
-apps
+apps/
 
 # OSTree files #
 ################

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ INCLUDE+ Dockerfile.lxc
 INCLUDE+ Dockerfile.docker
 INCLUDE+ Dockerfile.podman
 INCLUDE+ Dockerfile.openrc
-INCLUDE+ Dockerfile.apps
 INCLUDE+ Dockerfile.ostree-initramfs
 INCLUDE+ Dockerfile.ostree
+INCLUDE+ Dockerfile.apps
 

--- a/Dockerfile.apps
+++ b/Dockerfile.apps
@@ -1,3 +1,3 @@
-RUN mkdir /var/apps
-COPY apps/docker-compose.yml /var/apps
+RUN mkdir -p /usr/apps
+COPY apps/docker-compose.yml /usr/apps
 

--- a/Dockerfile.ostree
+++ b/Dockerfile.ostree
@@ -42,11 +42,6 @@ RUN if [ -d var/lib/$NULIX_VIRT_BACKEND ]; then \
       mv var/lib/$NULIX_VIRT_BACKEND var-lib-$NULIX_VIRT_BACKEND; \
     fi
 
-# preserve var/apps
-RUN if [ -d var/apps ]; then \
-      mv var/apps var-apps; \
-    fi
-
 # preserve var/local
 RUN if [ -d var/local ]; then \
       mv var/local var-local; \
@@ -61,11 +56,6 @@ RUN rm -rf var/lib && \
 # get back var/local
 RUN if [ -d var-local ]; then \
       mv var-local var/local; \
-    fi
-
-# get back var/apps
-RUN if [ -d var-apps ]; then \
-      mv var-apps var/apps; \
     fi
 
 # get back var/lib/$NULIX_VIRT_BACKEND

--- a/openrc/apps/apps.initd
+++ b/openrc/apps/apps.initd
@@ -33,7 +33,7 @@ start_apps() {
 }
 
 start() {
-	cd /var/apps
+	cd /usr/apps
 	COMPOSE_FILE_SHA=$(sha256sum docker-compose.yml | cut -d " " -f 1)
 
 	# update apps or just start them?
@@ -53,7 +53,7 @@ start() {
 stop() {
 	ebegin "Stopping apps"
 
-	cd /var/apps
+	cd /usr/apps
 	docker compose stop
 
 	eend $?


### PR DESCRIPTION
Since ostree on its own does not update `/etc` and `/var` directories,
change the location of apps compose file to `/usr/apps` from `/var/apps`
for the time being. Custom OTA update client should revert that and
take care of `/var` updates.
