### PR TITLE
ostree-initramfs: remove uboot's mkimage tool

### DIFF
--- a/Dockerfile.ostree-initramfs
+++ b/Dockerfile.ostree-initramfs
@@ -41,6 +41,7 @@ RUN cd initramfs && \
 # cleanups
 RUN mv initramfs/initramfs.img /usr/lib/modules/*/ && \
     rm -rf initramfs
+RUN apk del u-boot-tools
 
 ###
 ### extract initramfs (for debugging only):


### PR DESCRIPTION
This tool is not needed in the initramfs runtime, only when
building the `uboot` compatible initramfs image.
