### PR TITLE
Dockerfile: remove Dockerfile.apps from rootfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ INCLUDE+ Dockerfile.podman
 INCLUDE+ Dockerfile.openrc
 INCLUDE+ Dockerfile.ostree-initramfs
 INCLUDE+ Dockerfile.ostree
-INCLUDE+ Dockerfile.apps
 


### PR DESCRIPTION
Don't include apps in the rootfs. They will be injected by the CI/CD builder.