### PR TITLE
ostree_repo: fix apps deployment when building ostree repo

### DIFF
--- a/Dockerfile.ostree_repo
+++ b/Dockerfile.ostree_repo
@@ -41,8 +41,8 @@ RUN mkdir ${OSTREE_ROOTFS} && \
 RUN rm -rf ${OSTREE_ROOTFS}/etc
 
 # deploy custom apps
-RUN mkdir -p /usr/apps
-COPY apps/docker-compose.yml /usr/apps
+RUN mkdir -p ${OSTREE_ROOTFS}/usr/apps
+COPY apps*/docker-compose.yml ${OSTREE_ROOTFS}/usr/apps
 
 # reuse existing repo if possible
 COPY ${OSTREE_REPO}* /${OSTREE_REPO}


### PR DESCRIPTION
Deploy apps in extracted rootfs location: ${OSTREE_ROOTFS}/usr/apps. Also, deploy them only if the apps directory exists.