### PR TITLE
ostree: set hostname within the /usr/etc folder

### DIFF
--- a/Dockerfile.aktualizr
+++ b/Dockerfile.aktualizr
@@ -31,4 +31,3 @@ RUN cd aktualizr && \
 
 # install uptane's aktualizr
 #COPY --from=build /rauc/build/rauc /usr/bin
-

--- a/Dockerfile.apps
+++ b/Dockerfile.apps
@@ -1,3 +1,2 @@
 RUN mkdir -p /usr/apps
 COPY apps/docker-compose.yml /usr/apps
-

--- a/Dockerfile.clearlinux
+++ b/Dockerfile.clearlinux
@@ -6,4 +6,3 @@ RUN cd /etc && \
     grep root /usr/share/defaults/etc/group > /etc/group && \
     echo 'root:!:::::::' > /etc/shadow
 CMD ["/bin/bash"]
-

--- a/Dockerfile.openrc
+++ b/Dockerfile.openrc
@@ -1,5 +1,4 @@
 ARG MACHINE
-ARG HOSTNAME
 ARG VIRT_BACKEND
 ARG SERIAL_PORT
 ARG SERIAL_BAUD
@@ -27,10 +26,6 @@ RUN mv /sbin/poweroff.in /sbin/poweroff && \
     mv /sbin/reboot.in /sbin/reboot && \
     chmod +x /sbin/poweroff && \
     chmod +x /sbin/reboot
-
-# workaround hostname issue
-RUN sed -i "s|/etc/hostname|/etc/machine|g" /etc/init.d/hostname
-RUN echo -n "$HOSTNAME" > /etc/machine
 
 # custom services
 COPY openrc/apps/apps.initd /etc/init.d/apps

--- a/Dockerfile.ostree
+++ b/Dockerfile.ostree
@@ -4,6 +4,7 @@
 # https://github.com/uptane/meta-updater/blob/master/classes/image_types_ostree.bbclass
 
 ARG MACHINE
+ARG HOSTNAME
 ARG VIRT_BACKEND
 ARG DISTRO_VERSION_MAJOR
 ARG OSTREE_BRANCHNAME="$DISTRO_VERSION_MAJOR/stable/$MACHINE"
@@ -78,6 +79,10 @@ RUN mkdir sysroot && \
 # > [2/2] RUN mv /etc /usr:
 # 1.915 mv: can't remove '/etc/resolv.conf': Device or resource busy
 # 1.915 mv: can't remove '/etc/hosts': Device or resource busy
+
+# workaround hostname issue
+RUN cd usr/etc && \
+    echo -n "$HOSTNAME" > hostname
 
 # make this symlink otherwise '/etc/resolv.conf' will be reported
 # as modified when running `ostree admin config-diff` because

--- a/Dockerfile.rauc
+++ b/Dockerfile.rauc
@@ -41,4 +41,3 @@ COPY --from=build /rauc/build/data/de.pengutronix.rauc.conf /usr/share/dbus-1/sy
 # install rauc-hawkbit-updater
 COPY rauc/hawkbit-updater/config.conf.in /etc/rauc-hawkbit-updater/config.conf
 COPY --from=build /rauc-hawkbit-updater/build/rauc-hawkbit-updater /usr/bin
-

--- a/Dockerfile.recovery
+++ b/Dockerfile.recovery
@@ -47,4 +47,3 @@ FROM scratch
 
 # copy build artifacts
 COPY --from=build /initramfs-recovery /
-

--- a/Dockerfile.swupdate
+++ b/Dockerfile.swupdate
@@ -48,4 +48,3 @@ COPY --from=build /swupdate/libswupdate.so.0.1 /usr/lib
 RUN cd /usr/lib && ln -sf libswupdate.so.* libswupdate.so
 COPY swupdate/swupdate.cfg.in /etc/swupdate/swupdate.cfg
 COPY swupdate/swupdate-public.pem /etc/swupdate/
-


### PR DESCRIPTION
Since we are not able to modify the hostname during regular docker build commands, do this when /etc is already part of the merged /usr directory.