### PR TITLE
rootfs: add support to grow the rootfs partition

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -23,6 +23,8 @@ RUN apk add --no-cache \
     chrony \
     dosfstools \
     e2fsprogs \
+    e2fsprogs-extra \
+    parted \
     htop \
     iproute2 \
     openssh

--- a/Dockerfile.openrc
+++ b/Dockerfile.openrc
@@ -33,6 +33,7 @@ COPY openrc/tmpfiles/tmpfiles.initd /etc/init.d/tmpfiles
 COPY openrc/ostree/touch-ostree.initd /etc/init.d/touch-ostree
 COPY openrc/upd8/upd8.initd /etc/init.d/upd8
 COPY openrc/upd8/upd8.confd /etc/conf.d/upd8
+COPY openrc/resize-rootfs/resize-rootfs.initd /etc/init.d/resize-rootfs
 # COPY openrc/mountfs/mountfs.initd /etc/init.d/mountfs
 # RUN sed -i "s/@@NULIX_VIRT_BACKEND@@/${NULIX_VIRT_BACKEND}/g" /etc/init.d/mountfs
 #COPY openrc/rauc/rauc.initd /etc/init.d/rauc
@@ -58,6 +59,7 @@ RUN if [[ "$MACHINE_HAS_RTC" == "true" ]]; then \
 RUN rc-update add modules boot
 # RUN rc-update add mountfs boot
 RUN rc-update add networking boot
+RUN rc-update add resize-rootfs boot
 #RUN rc-update add rauc boot
 RUN rc-update add sysctl boot
 #RUN rc-update add rauc-hawkbit-updater default

--- a/openrc/resize-rootfs/resize-rootfs.initd
+++ b/openrc/resize-rootfs/resize-rootfs.initd
@@ -1,0 +1,30 @@
+#!/sbin/openrc-run
+
+# Copyright (c) NULIX 2025
+# This code is licensed under BSD-2-Clause
+
+name="Resize rootfs partition"
+description="Service to grow the rootfs partition to the full size of the storage device"
+
+depend() {
+	keyword -prefix -lxc -docker
+}
+
+start() {
+	if [ -f /var/cache/resize-rootfs ]; then
+		einfo "The rootfs partition is already resized!"
+		return 0
+	fi
+
+	ebegin "Starting root filesystem resize service"
+
+	ROOT_PART=$(mount | grep ' on / ' | awk '{print $1}')
+	DISK_DEV=$(echo "$ROOT_PART" | sed -E 's/p?[0-9]+$//')
+
+	parted --script "$DISK_DEV" resizepart ${ROOT_PART##*p} 100%
+	e2fsck -f "$ROOT_PART" || true
+	resize2fs "$ROOT_PART"
+	touch /var/cache/resize-rootfs
+
+	eend $?
+}


### PR DESCRIPTION
This will grow the rootfs partition to the full size of the storage device.